### PR TITLE
Fix JEI subtype interpreter for TrinketItems

### DIFF
--- a/src/main/java/com/mcjty/fancytrinkets/compat/FancyJeiPlugin.java
+++ b/src/main/java/com/mcjty/fancytrinkets/compat/FancyJeiPlugin.java
@@ -1,9 +1,6 @@
 package com.mcjty.fancytrinkets.compat;
 
 import com.mcjty.fancytrinkets.FancyTrinkets;
-import com.mcjty.fancytrinkets.datapack.CustomRegistries;
-import com.mcjty.fancytrinkets.datapack.TrinketDescription;
-import com.mcjty.fancytrinkets.modules.trinkets.TrinketsModule;
 import com.mcjty.fancytrinkets.modules.xpcrafter.XpCrafterModule;
 import com.mcjty.fancytrinkets.modules.xpcrafter.blocks.ExperienceCrafterBE;
 import com.mcjty.fancytrinkets.modules.xpcrafter.recipe.XpRecipe;
@@ -14,16 +11,14 @@ import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.helpers.IJeiHelpers;
-import mezz.jei.api.ingredients.IIngredientTypeWithSubtypes;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.registration.*;
 import net.minecraft.client.Minecraft;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.RegistryObject;
 
 import java.util.List;
-import java.util.Map;
 
 @JeiPlugin
 public class FancyJeiPlugin implements IModPlugin {
@@ -44,10 +39,14 @@ public class FancyJeiPlugin implements IModPlugin {
 
     @Override
     public void registerItemSubtypes(ISubtypeRegistration registration) {
-        for (Registration.TrinketInfo info : Registration.TRINKET_ITEMS.values()) {
-            registration.useNbtForSubtypes(info.item().get());
-            registration.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, info.item().get(), new XpRecipeSubtypeInterpreter());
-        }
+        Registration.TRINKET_ITEMS.values()
+            .stream()
+            .map(Registration.TrinketInfo::item)
+            .map(RegistryObject::get)
+            .distinct()
+            .forEach(item -> {
+                registration.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, item, TrinketItemSubtypeInterpreter.INSTANCE);
+            });
     }
 
     @Override

--- a/src/main/java/com/mcjty/fancytrinkets/compat/TrinketItemSubtypeInterpreter.java
+++ b/src/main/java/com/mcjty/fancytrinkets/compat/TrinketItemSubtypeInterpreter.java
@@ -6,7 +6,12 @@ import mezz.jei.api.ingredients.subtypes.UidContext;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 
-public class XpRecipeSubtypeInterpreter implements IIngredientSubtypeInterpreter<ItemStack> {
+public class TrinketItemSubtypeInterpreter implements IIngredientSubtypeInterpreter<ItemStack> {
+    public static final TrinketItemSubtypeInterpreter INSTANCE = new TrinketItemSubtypeInterpreter();
+
+    private TrinketItemSubtypeInterpreter() {
+
+    }
 
     @Override
     public String apply(ItemStack ingredient, UidContext context) {


### PR DESCRIPTION
The issue is that `useNbtForSubtypes` creates a subtype interpreter that pays attention to all NBT (which you do not want).
The interpreter you wrote is correct but unfortunately it fails to get registered because `useNbtForSubtypes` was already used, and we can only have one interpreter per item.

`[22:46:36] [Render thread/ERROR] [me.je.co.lo.re.SubtypeRegistration/]: An interpreter is already registered for this: gold_ring_blue`

With this PR, the recipe appears to work as expected :)